### PR TITLE
支持 Vim 模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Word Splitting for Simplified Chinese in Edit Mode
+# Word Splitting for Simplified Chinese in Edit Mode and Vim Mode
 
-A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting
+A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting in Edit Mode and Vim Mode
 
-增加 Obsidian 内置编辑器的(简体)中文分词支持，使得编辑模式的双击可以选中中文
+增加 Obsidian 内置编辑器的(简体)中文分词支持，使得编辑模式的双击可以选中中文，以及在 Vim 模式下可以按中文分词移动光标
 
 Special Thanks to [@fengkx](https://github.com/fengkx) for [jieba-wasm module](https://github.com/fengkx/jieba-wasm)
 
-注意：从v1.8.0开始，默认分词引擎由结巴分词更换为系统自带分词引擎，结巴分词不再是必须组件，若你需要结合[omnisearch](https://github.com/scambier/obsidian-omnisearch)插件使用，或仍需要使用结巴分词提供的更精确的分词结果，以及新词发现、自定义词库功能，请在设置打开选项后重启obsidian，并按照弹窗提示进行安装（若系统不提供分词引擎，无论选项本插件仍会提示安装结巴分词）
+注意：从 v1.8.0 开始，默认分词引擎由结巴分词更换为系统自带分词引擎，结巴分词不再是必备组件，若你需要结合 [omnisearch](https://github.com/scambier/obsidian-omnisearch) 插件使用，或仍需要使用结巴分词提供的更精确的分词结果，以及新词发现、自定义词库功能，请在设置打开选项后，按照弹窗提示进行安装（若系统不提供分词引擎，无论选项是否打开，本插件仍会提示安装结巴分词）
 
-手动安装结巴分词组件：在设置中启用结巴分词后，从[蓝奏云](https://wwe.lanzoum.com/igUPR00jp02h)或[GitHub](https://github.com/aidenlx/cm-chs-patch/blob/master/assets/jiaba-wasm/jieba_rs_wasm_bg.wasm.zip?raw=true)下载并解压得到`jieba_rs_wasm_bg.wasm`，将wasm文件放在obsidian库的`.obsidian`或者其它指定的配置文件夹下后重启obsidian
+手动安装结巴分词组件：在设置中启用结巴分词后，从[蓝奏云](https://wwe.lanzoum.com/igUPR00jp02h)或[GitHub](https://github.com/aidenlx/cm-chs-patch/blob/master/assets/jiaba-wasm/jieba_rs_wasm_bg.wasm.zip?raw=true)下载并解压得到 `jieba_rs_wasm_bg.wasm` 文件，将 wasm 文件放在 Obsidian 库的 `.obsidian` 或者其它指定的配置文件夹下后重启 Obsidian
 
 ## Demo
 
@@ -18,9 +18,9 @@ Special Thanks to [@fengkx](https://github.com/fengkx) for [jieba-wasm module](h
 
 ## Compatibility 兼容性
 
-The required API feature is only available for Obsidian v0.13.8+.
+The required API feature is only available for Obsidian v0.15.0+
 
-本插件仅支持v0.13.24以上的版本
+本插件仅支持 v0.15.0 以上的版本
 
 ## Installation 安装
 
@@ -29,7 +29,7 @@ The required API feature is only available for Obsidian v0.13.8+.
 1. Open `Settings` > `Third-party plugin`
 2. Make sure Safe mode is **off**
 3. Click `Browse community plugins`
-4. Search for this plugin
+4. Search for this plugin `Word Splitting for Simplified Chinese in Edit Mode and Vim Mode`
 5. Click `Install`
 6. Once installed, close the community plugins window and the patch is ready to use.
 
@@ -38,14 +38,14 @@ The required API feature is only available for Obsidian v0.13.8+.
 1. 打开`设置`>`第三方插件`
 2. 确保安全模式为`关闭`
 3. 点击`浏览社区插件`
-4. 搜索此插件
+4. 搜索此插件 `Word Splitting for Simplified Chinese in Edit Mode and Vim Mode`
 5. 点击`安装`
 6. 安装完成后，关闭安装窗口，插件即可使用
 
 ### From GitHub
 
 1. Download the Latest Release from the Releases section of the GitHub Repository
-2. Put files to your vault's plugins folder: `<vault>/.obsidian/plugins/cm-chs-patch`  
+2. Put files to your vault's plugins folder: `<vault>/.obsidian/plugins/cm-chs-patch`
 3. Reload Obsidian
 4. If prompted about Safe Mode, you can disable safe mode and enable the plugin.
 Otherwise head to Settings, third-party plugins, make sure safe mode is off and
@@ -55,9 +55,9 @@ enable the plugin from there.
 
 ***
 
-1. 从GitHub仓库的Releases下载最新版本
-2. 把文件放在对应Vault的插件文件夹下：`<vault>/.obsidian/plugins/cm-chs-patch`
-3. 重新加载Obsidian
+1. 从 GitHub 仓库的 Releases 下载最新版本
+2. 把文件放在对应 Vault 的插件文件夹下：`<vault>/.obsidian/plugins/cm-chs-patch`
+3. 重新加载 Obsidian
 4. 如果出现有关安全模式的提示，则可以禁用安全模式并启用插件。否则，请转到`设置`→`第三方插件`，确保关闭安全模式，然后从`第三方插件`启用插件
 
-> 注意，`.obsidian`文件夹为隐藏文件夹，在macOS的Finder下可以按`Command+Shift+.`以显示隐藏文件夹
+> 注意，`.obsidian` 文件夹为隐藏文件夹，在 macOS 的 Finder 下可以按 `Command+Shift+.` 以显示隐藏文件夹

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "cm-chs-patch",
-  "name": "Word Splitting for Simplified Chinese in Edit Mode",
+  "name": "Word Splitting for Simplified Chinese in Edit Mode and Vim Mode",
   "version": "1.8.2",
   "minAppVersion": "0.15.0",
   "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
   "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",
   "author": "AidenLx",
   "authorUrl": "https://github.com/AidenLx",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "assert-never": "^1.2.1",
     "file-select-dialog": "^1.5.4",
     "jieba-wasm": "^0.0.2",
+    "unzipit": "^1.4.0",
     "monkey-around": "^2.3.0",
     "cm6-view-src": "https://github.com/aidenlx/view/tarball/main"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aidenlx/chs-patch",
+  "name": "@aidenlx/cm-chs-patch",
   "version": "1.8.2",
   "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",
   "private": true,

--- a/src/chsp-main.ts
+++ b/src/chsp-main.ts
@@ -125,17 +125,25 @@ export default class CMChsPatch extends Plugin {
     nextPos: number,
     sliceDoc: (from: number, to: number) => string,
   ): number | null {
+    const oldNextPos = nextPos;
     const forward = startPos < nextPos;
     if (Math.abs(startPos - nextPos) > RANGE_LIMIT) {
       nextPos = startPos + RANGE_LIMIT * (forward ? 1 : -1);
     }
 
-    const text = forward
+    let text = forward
       ? sliceDoc(startPos, nextPos)
       : sliceDoc(nextPos, startPos);
 
-    if (!/[\u4e00-\u9fa5]/.test(text)) {
-      return null;
+    if (!/[\u4e00-\u9fff]/.test(text)) {
+      if (oldNextPos == nextPos) {
+        return null;
+      } else { // 英文单词超过 RANGE_LIMIT 被截断，不执行截断优化策略
+        nextPos = oldNextPos;
+        text = forward
+        ? sliceDoc(startPos, nextPos)
+        : sliceDoc(nextPos, startPos);
+      }
     }
 
     const segResult = this.cut(text);

--- a/src/chsp-vim.ts
+++ b/src/chsp-vim.ts
@@ -5,8 +5,8 @@ export const VimPatcher = (plugin: CMChsPatch) => {
   const codeMirrorVimObject = (window as any).CodeMirrorAdapter?.Vim;
 
   function initialize() {
-    setEnableMoveByChineseWords(plugin.settings.useJieba && plugin.settings.moveByChineseWords);
-    setEnableMoveTillChinesePunctuation(plugin.settings.useJieba && plugin.settings.moveTillChinesePunctuation);
+    setEnableMoveByChineseWords((plugin.settings.useJieba || (window.Intl as any)?.Segmenter) && plugin.settings.moveByChineseWords);
+    setEnableMoveTillChinesePunctuation((plugin.settings.useJieba || (window.Intl as any)?.Segmenter) && plugin.settings.moveTillChinesePunctuation);
   }
 
   function setEnableMoveByChineseWords(enabled) {

--- a/src/chsp-vim.ts
+++ b/src/chsp-vim.ts
@@ -1,0 +1,333 @@
+import type CMChsPatch from "../chsp-main";
+import { cut as jiebaCut } from "./jieba";
+
+export const VimPatcher = (plugin: CMChsPatch) => {
+  const codeMirrorVimObject = (window as any).CodeMirrorAdapter?.Vim;
+
+  function initialize() {
+    setEnableMoveByChineseWords(plugin.settings.useJieba && plugin.settings.moveByChineseWords);
+    setEnableMoveTillChinesePunctuation(plugin.settings.useJieba && plugin.settings.moveTillChinesePunctuation);
+  }
+
+  function setEnableMoveByChineseWords(enabled) {
+    codeMirrorVimObject.defineMotion('moveByWords', (cm: any, head: { line: any, ch: any }, motionArgs: object) => {
+      return moveToWord(cm, head, motionArgs.repeat, !!motionArgs.forward,
+        !!motionArgs.wordEnd, !!motionArgs.bigWord, enabled);
+    });
+  }
+
+  function setEnableMoveTillChinesePunctuation(enabled) {
+    codeMirrorVimObject.defineMotion('moveToCharacter', (cm: any, head: { line: any, ch: any }, motionArgs: object) => {
+      var repeat = motionArgs.repeat;
+      recordLastCharacterSearch(0, motionArgs);
+      return moveToCharacter(cm, repeat, motionArgs.forward, motionArgs.selectedCharacter, enabled) || head;
+    });
+
+    codeMirrorVimObject.defineMotion('moveTillCharacter', (cm: any, head: { line: any, ch: any }, motionArgs: object) => {
+      var repeat = motionArgs.repeat;
+      var curEnd = moveToCharacter(cm, repeat, motionArgs.forward, motionArgs.selectedCharacter, enabled);
+      var increment = motionArgs.forward ? -1 : 1;
+      recordLastCharacterSearch(increment, motionArgs);
+      if (!curEnd) return null;
+      curEnd.ch += increment;
+      return curEnd;
+    });
+
+    codeMirrorVimObject.defineMotion('repeatLastCharacterSearch', (cm: any, head: { line: any, ch: any }, motionArgs: object) => {
+      var vimGlobalState = codeMirrorVimObject.getVimGlobalState_();
+      var lastSearch = vimGlobalState.lastCharacterSearch;
+      var repeat = motionArgs.repeat;
+      var forward = motionArgs.forward === lastSearch.forward;
+      var increment = (lastSearch.increment ? 1 : 0) * (forward ? -1 : 1);
+      cm.moveH(-increment, 'char');
+      motionArgs.inclusive = forward ? true : false;
+      var curEnd = moveToCharacter(cm, repeat, forward, lastSearch.selectedCharacter, enabled);
+      if (!curEnd) {
+        cm.moveH(increment, 'char');
+        return head;
+      }
+      curEnd.ch += increment;
+      return curEnd;
+    });
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+
+  // fork vim.js
+  function recordLastCharacterSearch(increment, args) {
+    var vimGlobalState = codeMirrorVimObject.getVimGlobalState_();
+    vimGlobalState.lastCharacterSearch.increment = increment;
+    vimGlobalState.lastCharacterSearch.forward = args.forward;
+    vimGlobalState.lastCharacterSearch.selectedCharacter = args.selectedCharacter;
+  }
+
+  function charIdxInLine(start, line, character, forward, includeChar) {
+    // Search for char in line.
+    // motion_options: {forward, includeChar}
+    // If includeChar = true, include it too.
+    // If forward = true, search forward, else search backwards.
+    // If char is not found on this line, do nothing
+    var idx;
+    if (forward) {
+      idx = line.indexOf(character, start + 1);
+      if (idx != -1 && !includeChar) {
+        idx -= 1;
+      }
+    } else {
+      idx = line.lastIndexOf(character, start - 1);
+      if (idx != -1 && !includeChar) {
+        idx += 1;
+      }
+    }
+    return idx;
+  }
+
+  function moveToCharacter(cm, repeat, forward, character, moveToChinesePuncuation) {
+    var cur = cm.getCursor();
+    var start = cur.ch;
+    var idx;
+    // 中英文标点映射
+    var chinese_punctuation_mapping = {
+      '.': '。',
+      ',': '，',
+      ':': '：',
+      '"': '“',
+      '[': '「',
+      ']': '」',
+      '(': '（',
+      ')': '）'
+    }
+    for (var i = 0; i < repeat; i++) {
+      var line = cm.getLine(cur.line);
+      idx = charIdxInLine(start, line, character, forward, true);
+
+      if (moveToChinesePuncuation && character.length == 1 && chinese_punctuation_mapping[character] != undefined) {
+        var punc_char = chinese_punctuation_mapping[character];
+        var punc_idx = charIdxInLine(start, line, punc_char, forward, true);
+
+        if (punc_idx == -1) {
+          idx = idx;
+        } else if (idx == -1) {
+          idx = punc_idx;
+        } else {
+          idx = forward ? Math.min(idx, punc_idx) : Math.max(idx, punc_idx);
+        }
+      }
+      if (idx == -1) {
+        return null;
+      }
+      start = idx;
+    }
+    return new Pos(cm.getCursor().line, idx);
+  }
+
+  function copyCursor(cur) {
+    return new Pos(cur.line, cur.ch);
+  }
+
+  function moveToWord(cm, cur, repeat, forward, wordEnd, bigWord, moveToChineseWord) {
+    var curStart = copyCursor(cur);
+    var words = [];
+    if (forward && !wordEnd || !forward && wordEnd) {
+      repeat++;
+    }
+    // For 'e', empty lines are not considered words, go figure.
+    var emptyLineIsWord = !(forward && wordEnd);
+    for (var i = 0; i < repeat; i++) {
+      var word = findWord(cm, cur, forward, bigWord, emptyLineIsWord, moveToChineseWord);
+      if (!word) {
+        var eodCh = lineLength(cm, cm.lastLine());
+        words.push(forward
+          ? { line: cm.lastLine(), from: eodCh, to: eodCh }
+          : { line: 0, from: 0, to: 0 });
+        break;
+      }
+      words.push(word);
+      cur = new Pos(word.line, forward ? (word.to - 1) : word.from);
+    }
+    var shortCircuit = words.length != repeat;
+    var firstWord = words[0];
+    var lastWord = words.pop();
+    if (forward && !wordEnd) {
+      // w
+      if (!shortCircuit && (firstWord.from != curStart.ch || firstWord.line != curStart.line)) {
+        // We did not start in the middle of a word. Discard the extra word at the end.
+        lastWord = words.pop();
+      }
+      return new Pos(lastWord.line, lastWord.from);
+    } else if (forward && wordEnd) {
+      return new Pos(lastWord.line, lastWord.to - 1);
+    } else if (!forward && wordEnd) {
+      // ge
+      if (!shortCircuit && (firstWord.to != curStart.ch || firstWord.line != curStart.line)) {
+        // We did not start in the middle of a word. Discard the extra word at the end.
+        lastWord = words.pop();
+      }
+      return new Pos(lastWord.line, lastWord.to);
+    } else {
+      // b
+      return new Pos(lastWord.line, lastWord.from);
+    }
+  }
+
+  var wordCharTest = [CodeMirror.isWordChar, function(ch) {
+    return ch && !CodeMirror.isWordChar(ch) && !/\s/.test(ch);
+  }], bigWordCharTest = [function(ch) {
+    return /\S/.test(ch);
+  }];
+
+  function isLine(cm, line) {
+    return line >= cm.firstLine() && line <= cm.lastLine();
+  }
+
+  function lineLength(cm, lineNum) {
+    return cm.getLine(lineNum).length;
+  }
+
+  function cut(text) {
+    if (!plugin.settings.useJieba && plugin.segmenter) {
+      return Array.from(plugin.segmenter.segment(text)).map(
+        (seg) => (seg as any).segment,
+      );
+    } else return jiebaCut(text, plugin.settings.hmm);
+  }
+
+  // from Obsidian 1.0.9
+  // /Applications/Obsidian.app/Contents/Resources/obsidian.asar/lib/codemirror/vim.js
+  function findWord(cm, cur, forward, bigWord, emptyLineIsWord, moveToChineseWord) {
+    var lineNum = cur.line;
+    var pos = cur.ch;
+    var line = cm.getLine(lineNum);
+    var dir = forward ? 1 : -1;
+    var charTests = bigWord ? bigWordCharTest : wordCharTest;
+
+    if (emptyLineIsWord && line == '') {
+      lineNum += dir;
+      line = cm.getLine(lineNum);
+      if (!isLine(cm, lineNum)) {
+        return null;
+      }
+      pos = (forward) ? 0 : line.length;
+    }
+
+    while (true) {
+      if (emptyLineIsWord && line == '') {
+        return { from: 0, to: 0, line: lineNum };
+      }
+      var stop = (dir > 0) ? line.length : -1;
+      var wordStart = stop, wordEnd = stop;
+      // Find bounds of next word.
+      while (pos != stop) {
+        var foundWord = false;
+
+        var from = Math.max(pos - 6, 0),
+          to = Math.min(pos + 6, line.length);
+        var text = line.slice(from, to);
+
+        // 中文行处理
+        if (moveToChineseWord && /[\u4e00-\u9fff]/.test(text)) {
+          var segments = cut(text);
+
+          for (var i = 0; i < charTests.length && !foundWord; ++i) {
+            if (charTests[i](line.charAt(pos))) {
+              wordStart = pos;
+              // Advance to end of word.
+              var segment, segments = cut(line);
+              while (pos != stop) {
+                // 获取当前光标下的分词，跳过分隔字符
+                segment = segmentAt(segments, pos);
+                if (charTests[i](segment.text)) {
+                  if (forward) {
+                    pos = segment.end;
+                    pos = Math.min(pos, stop);
+                  } else {
+                    segment = segmentAt(segments, Math.max(--pos, 0));
+                    if (charTests[i](segment.text)) {
+                      pos = segment.begin - 1;
+                      pos = Math.max(pos, stop);
+                    } else {
+                      break;
+                    }
+                  }
+                  break;
+                }
+              }
+              wordEnd = pos;
+
+              foundWord = wordStart != wordEnd;
+              var foundEnd = forward ? Math.min(wordStart + dir, stop) : Math.max(wordStart + dir, stop);
+              // 如果光标在分词结尾字符（ +1 字符越界），跳过当前分词，查找下一个分词
+              if (wordStart == cur.ch && lineNum == cur.line &&
+                wordEnd == foundEnd) {
+                // We started at the end of a word. Find the next one.
+                continue;
+              } else {
+                return {
+                  from: Math.min(wordStart, wordEnd + 1),
+                  to: Math.max(wordStart, wordEnd),
+                  line: lineNum
+                };
+              }
+            }
+          }
+        }
+
+        // 英文行处理
+        for (var i = 0; i < charTests.length && !foundWord; ++i) {
+          if (charTests[i](line.charAt(pos))) {
+            wordStart = pos;
+            // Advance to end of word.
+            while (pos != stop && charTests[i](line.charAt(pos))) {
+              pos += dir;
+            }
+            wordEnd = pos;
+            foundWord = wordStart != wordEnd;
+            if (wordStart == cur.ch && lineNum == cur.line &&
+              wordEnd == wordStart + dir) {
+              // We started at the end of a word. Find the next one.
+              continue;
+            } else {
+              return {
+                from: Math.min(wordStart, wordEnd + 1),
+                to: Math.max(wordStart, wordEnd),
+                line: lineNum
+              };
+            }
+          }
+        }
+        if (!foundWord) {
+          pos += dir;
+        }
+      }
+      // Advance to next/prev line.
+      lineNum += dir;
+      if (!isLine(cm, lineNum)) {
+        return null;
+      }
+      line = cm.getLine(lineNum);
+      pos = (dir > 0) ? 0 : line.length;
+    }
+  }
+
+  function segmentAt(segments, pos) {
+    var chunkBegin = 0,
+      chunkEnd = 0;
+    for (var index = 0; index < segments.length; index++) {
+      var segment = segments[index];
+      chunkEnd = chunkBegin + segment.length;
+      if (pos >= chunkBegin && pos < chunkEnd) {
+        break;
+      }
+      chunkBegin += segment.length;
+    }
+
+    return {
+      index: index,
+      text: segment,
+      begin: chunkBegin,
+      end: chunkEnd
+    };
+  }
+
+  return { initialize: initialize };
+}

--- a/src/install-guide.ts
+++ b/src/install-guide.ts
@@ -1,5 +1,6 @@
 import { fileDialog } from "file-select-dialog";
-import { Modal } from "obsidian";
+import { Modal, Notice, requestUrl } from "obsidian";
+import { unzip } from 'unzipit';
 
 import type CMChsPatch from "./chsp-main";
 
@@ -9,18 +10,20 @@ const colorSuccess = "var(--background-modifier-success)",
 export default class GoToDownloadModal extends Modal {
   reloadButton: HTMLButtonElement | null = null;
   selectButton: HTMLButtonElement | null = null;
+  downloadButton: HTMLButtonElement | null = null;
 
   constructor(public plugin: CMChsPatch) {
     super(plugin.app);
     this.modalEl.addClass("zt-install-guide");
   }
 
-  downloadLink = `https://github.com/aidenlx/cm-chs-patch/blob/master/assets/jiaba-wasm/${this.libName}.zip?raw=true`;
+  downloadLink = `https://raw.githubusercontent.com/aidenlx/cm-chs-patch/main/assets/jiaba-wasm/${this.libName}.zip`;
   lanzoumLink = "https://wwe.lanzoum.com/igUPR00jp02h";
 
   get libName() {
     return this.plugin.libName;
   }
+
   onOpen() {
     this.contentEl.createEl("h1", { text: "安装结巴分词" });
     this.contentEl.createDiv({}, (div) => {
@@ -36,15 +39,23 @@ export default class GoToDownloadModal extends Modal {
           li.createEl("a", { href: this.downloadLink, text: "GitHub" });
           li.appendText(" 或 ");
           li.createEl("a", { href: this.lanzoumLink, text: "蓝奏云" });
-          li.appendText(" 下载");
+          li.appendText(" 手动下载");
+          li.appendText(" 或 ");
+
+          this.downloadButton = li.createEl(
+            "button",
+            { text: "自动下载" },
+            (btn) => (btn.onclick = this.onDownloadingFile.bind(this)),
+          );
         });
         ol.createEl("li", {}, (li) => {
-          li.appendText("解压缩zip包得到 ");
+          li.appendText("解压缩 zip 包得到 ");
           li.createEl("code", { text: this.libName });
         });
         ol.createEl("li", {}, (li) => {
           li.appendText("在弹出的窗口选择 ");
           li.createEl("code", { text: this.libName });
+          li.appendText("  ");
           this.selectButton = li.createEl(
             "button",
             { text: "选择文件" },
@@ -52,7 +63,7 @@ export default class GoToDownloadModal extends Modal {
           );
         });
         ol.createEl("li", {}, (li) => {
-          li.appendText("重新加载分词插件: ");
+          li.appendText("重新加载分词插件:  ");
           this.reloadButton = li.createEl(
             "button",
             { text: "重新加载" },
@@ -90,9 +101,39 @@ export default class GoToDownloadModal extends Modal {
       this.reloadButton.style.backgroundColor = "";
     }
   }
+  async onDownloadingFile() {
+    if (this.reloadButton) {
+      this.reloadButton.disabled = true;
+      this.reloadButton.style.backgroundColor = colorDisabled;
+    }
+
+    const resp = await requestUrl({url: this.downloadLink, contentType: "application/octet-stream"});
+    const { entries } = await unzip(resp.arrayBuffer);
+    if (entries[`${this.libName}`]) {
+      await this.app.vault.adapter.writeBinary(this.plugin.libPath, await entries[`${this.libName}`].arrayBuffer());
+    }
+
+    if (this.selectButton) {
+      this.selectButton.setText("结巴分词插件导入成功");
+      this.selectButton.style.backgroundColor = colorSuccess;
+    }
+    if (this.reloadButton) {
+      this.reloadButton.disabled = false;
+      this.reloadButton.style.backgroundColor = "";
+    }
+  }
   async onReloadPlugin() {
-    await this.app.plugins.disablePlugin(this.plugin.manifest.id);
-    this.close();
-    await this.app.plugins.enablePlugin(this.plugin.manifest.id);
+    if (await app.vault.adapter.exists(this.plugin.libPath, true)) {
+      const stat = await app.vault.adapter.stat(this.plugin.libPath);
+      if (stat && stat.type == "file" && stat.size > 0) {
+        await this.app.plugins.disablePlugin(this.plugin.manifest.id);
+        this.close();
+        await this.app.plugins.enablePlugin(this.plugin.manifest.id);
+        await this.app.setting.openTabById(this.plugin.manifest.id);
+      }
+      new Notice("✔️ 安装结巴分词插件成功");
+    } else {
+      new Notice("❌ 安装结巴分词插件失败");
+    }
   }
 }

--- a/src/install-guide.ts
+++ b/src/install-guide.ts
@@ -82,7 +82,7 @@ export default class GoToDownloadModal extends Modal {
       await file.arrayBuffer(),
     );
     if (this.selectButton) {
-      this.selectButton.setText("结巴分词插件加载成功");
+      this.selectButton.setText("结巴分词插件导入成功");
       this.selectButton.style.backgroundColor = colorSuccess;
     }
     if (this.reloadButton) {

--- a/src/install-guide.ts
+++ b/src/install-guide.ts
@@ -82,7 +82,7 @@ export default class GoToDownloadModal extends Modal {
       await file.arrayBuffer(),
     );
     if (this.selectButton) {
-      this.selectButton.setText("结巴分词导入成功");
+      this.selectButton.setText("结巴分词插件加载成功");
       this.selectButton.style.backgroundColor = colorSuccess;
     }
     if (this.reloadButton) {

--- a/src/jieba.ts
+++ b/src/jieba.ts
@@ -19,6 +19,7 @@ export const initJieba = async (
   await init(wasm);
   if (dict)
     for (const line of dict.split(/\r?\n/)) {
+      // eg: 集团公司 1297 n
       const [word, freqOrTag, tag] = line.trim().split(/\s+/);
       let f: number | undefined, t: keyof typeof vaildTags | undefined;
       if (!word) {
@@ -46,32 +47,32 @@ export const cut = (text: string, hmm = false) => {
 };
 
 const vaildTags = {
-  n: undefined,
-  f: undefined,
-  s: undefined,
-  t: undefined,
-  nr: undefined,
-  ns: undefined,
-  nt: undefined,
-  nw: undefined,
-  nz: undefined,
-  v: undefined,
-  vd: undefined,
-  vn: undefined,
-  a: undefined,
-  ad: undefined,
-  an: undefined,
-  d: undefined,
-  m: undefined,
-  q: undefined,
-  r: undefined,
-  p: undefined,
-  c: undefined,
-  u: undefined,
-  xc: undefined,
-  w: undefined,
-  PER: undefined,
-  LOC: undefined,
-  ORG: undefined,
-  TIME: undefined,
+  n: undefined, // 普通名词
+  f: undefined, // 方位名词
+  s: undefined, // 处所名词
+  t: undefined, // 时间
+  nr: undefined, // 人名
+  ns: undefined, // 地名
+  nt: undefined, // 机构名
+  nw: undefined, // 作品名
+  nz: undefined, // 其他专名
+  v: undefined, // 普通动词
+  vd: undefined, // 动副词
+  vn: undefined, // 名动词
+  a: undefined, // 形容词
+  ad: undefined, // 副形词
+  an: undefined, // 名形词
+  d: undefined, // 副词
+  m: undefined, // 数量词
+  q: undefined, // 量词
+  r: undefined, // 代词
+  p: undefined, // 介词
+  c: undefined, // 连词
+  u: undefined, // 助词
+  xc: undefined, // 其他虚词
+  w: undefined, // 标点符号
+  PER: undefined, // 人名
+  LOC: undefined, // 地名
+  ORG: undefined, // 机构名
+  TIME: undefined, // 时间
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,7 +36,8 @@ export class ChsPatchSettingTab extends PluginSettingTab {
 
     this.addToggle(containerEl, "useJieba")
       .setName("使用结巴分词")
-      .setDesc("支持新词发现、自定义词典，需要额外下载，重启obsidian生效");
+      .setDesc("支持新词发现、自定义词典，需要额外下载，重启 Obsidian 生效");
+
 
     if (this.plugin.settings.useJieba || !(window.Intl as any)?.Segmenter) {
       this.addToggle(containerEl, "hmm")
@@ -92,9 +93,11 @@ export class ChsPatchSettingTab extends PluginSettingTab {
       toggle
         .setValue(this.plugin.settings[key])
         .onChange(
-          (value) => (
-            (this.plugin.settings[key] = value), this.plugin.saveSettings()
-          ),
+          (value) => {
+            this.plugin.settings[key] = value;
+            this.plugin.saveSettings();
+            if (key == "useJieba") this.display();
+          }
         );
     });
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,12 +8,16 @@ export interface ChsPatchSetting {
   useJieba: boolean;
   hmm: boolean;
   dict: string;
+  moveByChineseWords: boolean;
+  moveTillChinesePunctuation: boolean;
 }
 
 export const DEFAULT_SETTINGS: ChsPatchSetting = {
   useJieba: false,
   hmm: false,
   dict: "",
+  moveByChineseWords: false,
+  moveTillChinesePunctuation: false,
 };
 
 type SettingKeyWithType<T> = {
@@ -67,6 +71,18 @@ export class ChsPatchSettingTab extends PluginSettingTab {
               await this.app.plugins.enablePlugin(this.plugin.manifest.id);
               this.app.setting.openTabById(this.plugin.manifest.id);
             }),
+        );
+
+      this.addToggle(containerEl, "moveByChineseWords")
+        .setName("使用结巴分词移动光标 in Normal Mode")
+        .setDesc(
+          "Motion w/e/b/ge 移动使用结巴分词移动光标 in Normal Mode",
+        );
+
+      this.addToggle(containerEl, "moveTillChinesePunctuation")
+        .setName("f<character> 和 t<character> 支持输入英文标点跳转到中文标点")
+        .setDesc(
+          "Motion f<character> 和 t<character> 支持输入英文标点跳转到中文标点",
         );
     }
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,20 +73,21 @@ export class ChsPatchSettingTab extends PluginSettingTab {
               this.app.setting.openTabById(this.plugin.manifest.id);
             }),
         );
+    }
 
-      if (app.vault.config.vimMode == true) {
-        this.addToggle(containerEl, "moveByChineseWords")
-          .setName("【Vim Mode】使用结巴分词移动光标")
-          .setDesc(
-            "Motion w/e/b/ge 使用结巴分词移动光标 in Vim Normal Mode",
-            );
+    if ((this.plugin.settings.useJieba || (window.Intl as any)?.Segmenter)
+      && app.vault.config.vimMode == true) {
+      this.addToggle(containerEl, "moveByChineseWords")
+      .setName("【Vim Mode】使用结巴分词移动光标")
+      .setDesc(
+        "Motion w/e/b/ge 使用结巴分词移动光标 in Vim Normal Mode",
+        );
 
-        this.addToggle(containerEl, "moveTillChinesePunctuation")
-          .setName("【Vim Mode】f/t<character> 支持输入英文标点跳转到中文标点")
-          .setDesc(
-            "Motion f/t<character> 支持输入英文标点跳转到中文标点 in Vim Normal Mode",
-            );
-      }
+      this.addToggle(containerEl, "moveTillChinesePunctuation")
+      .setName("【Vim Mode】f/t<character> 支持输入英文标点跳转到中文标点")
+      .setDesc(
+        "Motion f/t<character> 支持输入英文标点跳转到中文标点 in Vim Normal Mode",
+        );
     }
   }
 


### PR DESCRIPTION
1. 支持 Vim 模式下移动中文单词 #4
2. 支持 Vim 模式下输入英文标点跳转到对应的中文标点（不确定放在这个插件里是否合适）
3. 支持后台自动下载 jieba-wasm 插件，简化安装步骤
4. 修复中英文混排情况下，英文单词超过 RANGE_LIMIT 被截断跳转异常的问题 #14 

Review 无问题的话，升级版本号发布。